### PR TITLE
Fix document API 404 errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "companies-house-mcp-server",
-  "version": "2.0.1",
+  "version": "3.0.0",
   "description": "MCP server for Companies House API integration",
   "main": "dist/index.js",
   "type": "module",

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -23,7 +23,7 @@ export class CompaniesHouseApiClient {
     this.filing = new FilingApiClient(config);
     this.charges = new ChargesApiClient(config);
     this.psc = new PSCApiClient(config);
-    this.document = new DocumentApiClient(config);
+    this.document = new DocumentApiClient(config.apiKey);
   }
 
   async testConnection(): Promise<boolean> {

--- a/src/api/document-api.ts
+++ b/src/api/document-api.ts
@@ -1,23 +1,49 @@
-import { BaseApiClient } from './base-client.js';
+import axios, { AxiosInstance } from 'axios';
 import type {
   DocumentMetadata,
   DocumentContent,
   DocumentMetadataResponse
 } from '../types/document.js';
 
-export class DocumentApiClient extends BaseApiClient {
+export class DocumentApiClient {
+  private documentClient: AxiosInstance;
+
+  constructor(apiKey: string) {
+    this.documentClient = axios.create({
+      baseURL: 'https://document-api.company-information.service.gov.uk',
+      auth: {
+        username: apiKey,
+        password: ''
+      },
+      timeout: 30000
+    });
+  }
+
   async getDocumentMetadata(params: DocumentMetadata): Promise<DocumentMetadataResponse> {
-    const response = await this.client.get(`/document/${params.document_id}`);
+    const documentId = this.extractDocumentId(params.document_id);
+    const response = await this.documentClient.get(`/document/${documentId}`, {
+      headers: {
+        Accept: 'application/json'
+      }
+    });
     return response.data;
   }
 
   async getDocumentContent(params: DocumentContent): Promise<Buffer> {
-    const response = await this.client.get(`/document/${params.document_id}/content`, {
+    const documentId = this.extractDocumentId(params.document_id);
+    const response = await this.documentClient.get(`/document/${documentId}/content`, {
       responseType: 'arraybuffer',
       headers: {
         Accept: 'application/pdf'
       }
     });
     return Buffer.from(response.data);
+  }
+
+  private extractDocumentId(input: string): string {
+    if (input.startsWith('https://document-api.company-information.service.gov.uk/document/')) {
+      return input.replace('https://document-api.company-information.service.gov.uk/document/', '');
+    }
+    return input;
   }
 }

--- a/tests/document-api.test.ts
+++ b/tests/document-api.test.ts
@@ -20,9 +20,7 @@ describe('DocumentApiClient', () => {
 
     (axios.create as ReturnType<typeof vi.fn>).mockReturnValue(mockAxiosInstance as AxiosInstance);
 
-    apiClient = new DocumentApiClient({
-      apiKey: 'test-api-key'
-    });
+    apiClient = new DocumentApiClient('test-api-key');
   });
 
   describe('getDocumentMetadata', () => {
@@ -45,7 +43,11 @@ describe('DocumentApiClient', () => {
 
       const result = await apiClient.getDocumentMetadata({ document_id: 'doc123' });
 
-      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/document/doc123');
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/document/doc123', {
+        headers: {
+          Accept: 'application/json'
+        }
+      });
       expect(result).toEqual(mockResponse.data);
     });
 


### PR DESCRIPTION
## Summary
- Fixed 404 errors when fetching document metadata and content from Companies House API
- Document API now uses the correct base URL (document-api.company-information.service.gov.uk)
- Added support for both plain document IDs and full URLs from filing history responses

## Changes
- Updated `DocumentApiClient` to use the correct document API base URL
- Added `extractDocumentId` method to handle both plain IDs and full document URLs
- Modified constructor to accept API key directly instead of config object
- Updated tests to match the new implementation

## Test Plan
- [x] All unit tests pass
- [x] Type checking passes
- [x] Linting and formatting completed
- [x] Tested with real Companies House API - successfully retrieved document metadata and PDF content
- [x] Verified both plain document IDs and full URLs work correctly

## Example
Document endpoints now work correctly:
- `get_document_metadata` - retrieves document metadata
- `get_document_content` - downloads PDF content

Tested with real document ID: `JC2F-QN2FxZvZBxZMLoNaeVALxaDhhWhQRwYKWevrxU`