### PR TITLE
ci: add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    reviewers:
+      - "stefanoamorelli"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    reviewers:
+      - "stefanoamorelli"
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    reviewers:
+      - "stefanoamorelli"


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` with weekly update checks for npm, GitHub Actions, and Docker ecosystems
- Enables Dependabot security alerts on the repo (matching sec-edgar-mcp setup)

## Test plan
- [ ] Verify Dependabot starts creating PRs for outdated dependencies after merge