### PR TITLE
chore: upgrade to Node.js 22 and drop Node.js 18 (EOL)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [20.x, 22.x]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [20.x, 22.x]
 
     steps:
     - uses: actions/checkout@v4
@@ -46,4 +46,4 @@ jobs:
         flags: unittests
         name: codecov-umbrella
         token: ${{ secrets.CODECOV_TOKEN }}
-      if: matrix.node-version == '20.x'
+      if: matrix.node-version == '22.x'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine AS builder
+FROM node:22-alpine AS builder
 
 # Create app directory
 WORKDIR /app
@@ -17,7 +17,7 @@ COPY src ./src
 RUN npm run build
 
 # Production stage
-FROM node:20-alpine
+FROM node:22-alpine
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary
- Upgrade Docker base image from `node:20-alpine` to `node:22-alpine`
- Update CI matrix from `[18.x, 20.x]` to `[20.x, 22.x]` (Node 18 is EOL)
- Update codecov upload condition to run on Node 22.x

## Test plan
- [ ] CI passes on both Node 20.x and 22.x
- [ ] Docker image builds successfully